### PR TITLE
fix: correctly import typings

### DIFF
--- a/src/compat/darksky-alert.ts
+++ b/src/compat/darksky-alert.ts
@@ -1,4 +1,4 @@
-import { Alert } from "types"
+import { Alert } from "../types"
 
 /**
  * Objects representing the severe weather warnings issued for the requested location

--- a/src/compat/darksky-request.ts
+++ b/src/compat/darksky-request.ts
@@ -1,4 +1,4 @@
-import { TimeMachineDate, ForecastRequest } from "types"
+import { TimeMachineDate, ForecastRequest } from "../types"
 
 /**
  * A DarkSky request object.


### PR DESCRIPTION
Fix: 'Cannot find module 'types' or its corresponding type declarations' by correctly importing
typings